### PR TITLE
Fix syntax errors on string comparator

### DIFF
--- a/plugins/filters/string_utils.py
+++ b/plugins/filters/string_utils.py
@@ -48,7 +48,7 @@ def clean(string):
 def count(haystack, needle):
     haystack = _string_sanity_check(haystack)
     needle = _string_sanity_check(needle)
-    if needle is '' or needle is None:
+    if needle == '' or needle is None:
         return 0
     return haystack.count(needle)
 
@@ -68,7 +68,7 @@ def dasherize(string):
 
 def decapitalize(string):
     sanitzed_string = _string_sanity_check(string)
-    if sanitzed_string is '' or sanitzed_string is None:
+    if sanitzed_string == '' or sanitzed_string is None:
         return ''
     return sanitzed_string[0].lower() + sanitzed_string[1:]
 
@@ -78,7 +78,7 @@ def decapitalize(string):
 
 def dedent(string):
     sanitzed_string = _string_sanity_check(string)
-    if sanitzed_string is '' or sanitzed_string is None:
+    if sanitzed_string == '' or sanitzed_string is None:
         return ''
     return textwrap.dedent(sanitzed_string)
 
@@ -113,7 +113,7 @@ def escape_html(haystack):
 
 
 def humanize(string):
-    if string is '' or string is None:
+    if string == '' or string is None:
         return ''
     sanitzed_string = _string_sanity_check(string)
     underscored = underscore(sanitzed_string)


### PR DESCRIPTION
When running via ansible 2.10.7 you are presented with a few SyntaxWarnings everytime a function is referenced, see below code block, this PR resolves this by swapping the `is` comparator for empty strings to `==` instead.

```
12:24:46  TASK [Get the current caller identity information] *****************************
12:24:47  ok: [localhost]
12:24:47  
12:24:47  TASK [update kube config] ******************************************************
12:24:47  /opt/ansible/plugins/ansible-filter-plugins/plugins/filters/string_utils.py:51: SyntaxWarning: "is" with a literal. Did you mean "=="?
12:24:47    if needle is '' or needle is None:
12:24:47  /opt/ansible/plugins/ansible-filter-plugins/plugins/filters/string_utils.py:71: SyntaxWarning: "is" with a literal. Did you mean "=="?
12:24:47    if sanitzed_string is '' or sanitzed_string is None:
12:24:47  /opt/ansible/plugins/ansible-filter-plugins/plugins/filters/string_utils.py:81: SyntaxWarning: "is" with a literal. Did you mean "=="?
12:24:47    if sanitzed_string is '' or sanitzed_string is None:
12:24:47  /opt/ansible/plugins/ansible-filter-plugins/plugins/filters/string_utils.py:116: SyntaxWarning: "is" with a literal. Did you mean "=="?
12:24:47    if string is '' or string is None:
12:24:58  ok: [localhost]
```